### PR TITLE
docs: fix simple typo, relavent -> relevant

### DIFF
--- a/code/2.7/adder.c
+++ b/code/2.7/adder.c
@@ -33,7 +33,7 @@ static PyObject* addList_add(PyObject* self, PyObject* args){
 static char addList_docs[] =
 "add(  ): add all elements of the list\n";
 
-/* This table contains the relavent info mapping -
+/* This table contains the relevant info mapping -
    <function-name in python module>, <actual-function>,
    <type-of-args the function expects>, <docstring associated with the function>
  */


### PR DESCRIPTION
There is a small typo in code/2.7/adder.c.

Should read `relevant` rather than `relavent`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md